### PR TITLE
TRITON-2310 Add i40e/intelxl PCI entries (fix typo)

### DIFF
--- a/src/drivers/net/intelxl.c
+++ b/src/drivers/net/intelxl.c
@@ -1812,7 +1812,7 @@ static struct pci_device_id intelxl_nics[] = {
 	PCI_ROM ( 0x8086, 0x1589, "x710-10gt4", "X710 10GBASE-T4", 0 ),
 	PCI_ROM ( 0x8086, 0x158a, "xxv710", "XXV710 25GbE backplane", 0 ),
 	PCI_ROM ( 0x8086, 0x158b, "xxv710-sfp28", "XXV710 25GbE SFP28", 0 ),
-	PCI_ROM ( 0x8086, 0x15ff, "x710-10gtl", "X710 10GBASE-TL", 0 ),
+	PCI_ROM ( 0x8086, 0x15ff, "x710-10gt-b", "X710 10GBASE-T", 0 ),
 	PCI_ROM ( 0x8086, 0x37ce, "x722-kx", "X722 10GbE backplane", 0 ),
 	PCI_ROM ( 0x8086, 0x37cf, "x722-qsfp", "X722 10GbE QSFP+", 0 ),
 	PCI_ROM ( 0x8086, 0x37d0, "x722-sfp", "X722 10GbE SFP+", 0 ),

--- a/src/drivers/net/intelxl.c
+++ b/src/drivers/net/intelxl.c
@@ -1812,7 +1812,7 @@ static struct pci_device_id intelxl_nics[] = {
 	PCI_ROM ( 0x8086, 0x1589, "x710-10gt4", "X710 10GBASE-T4", 0 ),
 	PCI_ROM ( 0x8086, 0x158a, "xxv710", "XXV710 25GbE backplane", 0 ),
 	PCI_ROM ( 0x8086, 0x158b, "xxv710-sfp28", "XXV710 25GbE SFP28", 0 ),
-	PCI_ROM ( 0x8086, 0x1599, "x710-10gtl", "X710 10GBASE-TL", 0 ),
+	PCI_ROM ( 0x8086, 0x15ff, "x710-10gtl", "X710 10GBASE-TL", 0 ),
 	PCI_ROM ( 0x8086, 0x37ce, "x722-kx", "X722 10GbE backplane", 0 ),
 	PCI_ROM ( 0x8086, 0x37cf, "x722-qsfp", "X722 10GbE QSFP+", 0 ),
 	PCI_ROM ( 0x8086, 0x37d0, "x722-sfp", "X722 10GbE SFP+", 0 ),


### PR DESCRIPTION
I think we gave our customer the right one, but now it's broken in-repo.