### PR TITLE
TRITON-2440 iPXE TCP transfers are either slow or failing after most recent update

### DIFF
--- a/src/include/ipxe/tcp.h
+++ b/src/include/ipxe/tcp.h
@@ -360,7 +360,7 @@ struct tcp_options {
  * We therefore choose a (rounded up) maximum window size of 2048kB.
  */
 /* #define TCP_MAX_WINDOW_SIZE	( 2048 * 1024 ) */
-/* XXX SmartOS... PSYCH! UNDIONLY doesn't like the big window size! */
+/* XXX TRITON... PSYCH! UNDIONLY doesn't like the big window size! */
 #define TCP_MAX_WINDOW_SIZE	( 256 * 1024 )
 
 /**

--- a/src/include/ipxe/tcp.h
+++ b/src/include/ipxe/tcp.h
@@ -359,7 +359,9 @@ struct tcp_options {
  *
  * We therefore choose a (rounded up) maximum window size of 2048kB.
  */
-#define TCP_MAX_WINDOW_SIZE	( 2048 * 1024 )
+/* #define TCP_MAX_WINDOW_SIZE	( 2048 * 1024 ) */
+/* XXX SmartOS... PSYCH! UNDIONLY doesn't like the big window size! */
+#define TCP_MAX_WINDOW_SIZE	( 256 * 1024 )
 
 /**
  * Path MTU


### PR DESCRIPTION
Since upstream won't make this a downstream tunable, we have to take this into our own hands.